### PR TITLE
v0.0.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# RETCON (Reticulum Embedded Turnkey Connection Operating Node) v0.0.5
+# RETCON (Reticulum Embedded Turnkey Connection Operating Node) v0.0.6
 
 Because complex networks shouldn't require complex setup.
 
@@ -113,13 +113,15 @@ Contributions are welcome and appreciated!
 - [x] Client mode where wifi AP password is different meshchat is launched automatically
 - [x] Web based app in client mode to instruct users how to connect to meshchat and change wifi ap details
 - [x] Captive portal in client mode directing to web app (retcon.local)
-- [ ] Set Meshchat default config from RETCON config file. (e.g. default ident name/announce/etc)
+- [x] Set Meshchat default config from RETCON config file. (e.g. default ident name/announce/etc)
 - [x] Ability to change from client to transport mode via admin interfaces
 - [x] Ability to change from client mode details from admin interface (like AP password)
 - [ ] Configure rpi-image-gen from retcon config (for things like ssh, username and extra apt packages)
 - [ ] Nomadnet/micron configuration interface for field adjustments
 - [ ] 'microRetcon' for hardware platforms (ESP32, etc.)
 - [ ] Integration with more transports (Bluetooth mesh, additional radio modules)
+- [ ] Better error handling around meshchat crashed
+- [ ] Wifi Mesh 2.0 protocol using raw 802.11 data frames (requires monitor mode. If you know how to do this let me know)
 
 
 ### Debugging, Dev and security Tips
@@ -127,9 +129,33 @@ Contributions are welcome and appreciated!
 SSH in enabled in the raspi build but disabled on first boot by RETCON. It can be temporarily turned on via the web interface. 
 default username is `retcon` and password is `retcon`. If the node is somewhere people have easy phsyical access to it (or if SSH server is turned on) then this absolutely needs to be changed! 
 
+You can change or configure files on teh SD card without booting. All retcon files are in `/home/retcon/retcon/` 
+
+
 ### Troubleshooting
 
-TODO 
+#### Wifi isn't connecting to the AP I set in wifi.prefix
+Make sure that the wifi frequencies are the same. Raspberry pi hardware can't connect to a network while hosting its own at the same time unless they are the same frequency. If you know the wifi channel, then use the below json object mapping (U.S. Based) to set the proper freqency:
+
+```
+wifi_channel_to_freq = {
+    1: 2412,
+    2: 2417,
+    3: 2422,
+    4: 2427,
+    5: 2432,
+    6: 2437,
+    7: 2442,
+    8: 2447,
+    9: 2452,
+    10: 2457,
+    11: 2462,
+    12: 2467,
+    13: 2472,
+    14: 2484
+}
+```
+Note. Only 2.4 Ghz wifi is supported for now. 
 
 ## License
 

--- a/build_retcon.sh
+++ b/build_retcon.sh
@@ -11,6 +11,12 @@ prompt_confirm() {
   done  
 }
 
+pathadd() {
+    if [ -d "$1" ] && [[ ":$PATH:" != *":$1:"* ]]; then
+        PATH="${PATH:+"$PATH:"}$1"
+    fi
+}
+
 # make sure our pwd is the same as the script
 SCRIPT=$(realpath "$0")
 SCRIPTPATH=$(dirname "$SCRIPT")
@@ -42,6 +48,10 @@ echo "Non debian based distros (e.g. fedora, arch, etc) will probably not work"
 echo ""
 
 prompt_confirm "ok to run?" || exit 0
+
+# ensure /usr/sbin is in path since it isn't normally for non-root user
+pathadd "/usr/sbin"
+pathadd "/sbin"
 
 sudo rm -rf $HOME/.retcon-build || true
 

--- a/retcon.py
+++ b/retcon.py
@@ -49,7 +49,7 @@ if __name__ == "__main__":
     
     # startup the ap, this is the same  whether we're a transport or client
 
-    # are we just a transport? or should we launch uis?
+    # are we just a transport? or should we launch ui?
     is_transport = r_config.get("mode", "client") == "transport"
     is_client = r_config.get("mode", "client") == "client"
     
@@ -89,7 +89,7 @@ if __name__ == "__main__":
         process.wait()
     
     print("Brought up AP now letting it settle")
-    time.sleep(10)
+    time.sleep(8)
     
     rnsd_tasks=[]
     
@@ -149,10 +149,10 @@ if __name__ == "__main__":
     #tasks to run if we're in ui mode
     # these wont be run if we're in transport mode
     async def run_ui_tasks():
-        await asyncio.sleep(5) # sleep for 5 seconds to allow server to settle
+        await asyncio.sleep(3) # sleep for a few seconds to allow server to settle
         print("Starting meshchat")
-        MeshchatHandle.start_meshchat(ap_iface, ssid)
-        await asyncio.sleep(1)
+        MeshchatHandle.start_meshchat(ap_iface, ssid, config)
+        await asyncio.sleep(2)
     
     async def run():
         # busy loop so we don't exit

--- a/retcon.py
+++ b/retcon.py
@@ -71,6 +71,16 @@ if __name__ == "__main__":
         psk = wifi_config['psk']
         
     channel = wifi_freq_to_channel[int(wifi_config["freq"])]
+    if is_transport:
+        # we can't have collisions so use the las bits of the node_id to generate an ipv4 subnet range 
+        ip_subnet_bytes = (node_id  & 0xFFFF).to_bytes(2)
+        # avoid collisions with client AP. That will girnd things to a hault for them
+        if ip_subnet_bytes[0] == 42 and ip_subnet_bytes[1] == 1:
+            ip_subnet_bytes = [42,2]
+        ip_subnet_str = f"10.{ip_subnet_bytes[0]}.{ip_subnet_bytes[1]}.1/24"
+    else:
+        ip_subnet_str ="10.42.0.1/24" # need these to always be the same for DNS to work and this is the default
+    
     
     # TODO: We should really use dbus directly for this, but nmcli is so much easier
     # Setup wifi interfaces
@@ -81,7 +91,7 @@ if __name__ == "__main__":
         f"nmcli con add con-name retcon_ap ifname {ap_iface} type wifi ssid '{ssid}'",
         f"nmcli con modify retcon_ap wifi-sec.key-mgmt wpa-psk",
         f"nmcli con modify retcon_ap wifi-sec.psk '{psk}' ",
-        f"nmcli con modify retcon_ap 802-11-wireless.mode ap 802-11-wireless.band bg 802-11-wireless.channel {channel} ipv4.method shared"
+        f"nmcli con modify retcon_ap 802-11-wireless.mode ap 802-11-wireless.band bg 802-11-wireless.channel {channel} ipv4.method shared ipv4.addresses {ip_subnet_str}"
     ]
     for command in commands:
         print(command)
@@ -89,7 +99,7 @@ if __name__ == "__main__":
         process.wait()
     
     print("Brought up AP now letting it settle")
-    time.sleep(8)
+    time.sleep(10)
     
     rnsd_tasks=[]
     

--- a/retcon_pi/retcon/meta/retcon-apps.yaml
+++ b/retcon_pi/retcon/meta/retcon-apps.yaml
@@ -10,6 +10,7 @@ mmdebstrap:
   - |-
     mkdir $1/home/$IGconf_device_user1/retcon
     cp -r $IGconf_ext_nsdir/../../* $1/home/$IGconf_device_user1/retcon
+    cp  $1/home/$IGconf_device_user1/retcon/README.md $1/README.md
   - |-
     chroot $1 bash -- <<- EOCHROOT
     cd /home/$IGconf_device_user1/retcon

--- a/retcon_pi/retcon/meta/retcon-apps.yaml
+++ b/retcon_pi/retcon/meta/retcon-apps.yaml
@@ -56,6 +56,10 @@ mmdebstrap:
     address=/mask-h2.icloud.com/
     EOCFGL
 
+    #TODO maybe add retcon user to group or something instead of just a+w here? 
+    chmod a+w /etc/NetworkManager/dnsmasq-shared.d/retcon_redirect.conf
+    chmod a+w /etc/hosts
+
     # download all the firware artifacts
     cd /home/$IGconf_device_user1/retcon/utils
     python3 download_firmware.py

--- a/retcon_pi/retcon/meta/wifi-mesh.yaml
+++ b/retcon_pi/retcon/meta/wifi-mesh.yaml
@@ -14,7 +14,6 @@ mmdebstrap:
   - |-
     chroot $1 bash -- <<- EOCHROOT
     source /home/$IGconf_device_user1/setup-wifi-mesh
-    #install_secrets $IGconf_device_user1 $IGconf_acme_dev_server
     touch /home/$IGconf_device_user1/retcon.INSTALLED
     echo "@reboot $IGconf_device_user1/retcon/start_retcon.sh" > /var/spool/cron/crontabs/$IGconf_device_user1
     printenv > /home/$IGconf_device_user1/retcon.ENV

--- a/retcon_profiles/dc33.config
+++ b/retcon_profiles/dc33.config
@@ -6,7 +6,7 @@
   # The mode to run in. Options are
   #   transport = headless transport. No Meshchat or other UI. No authentication.
   #   client    = AP serves a meshchat UI. Authentication handled by wifi auth. No transport
-  mode = transport
+  mode = client
   
   annouce_every = 360  # every 6 minutes
   
@@ -20,16 +20,28 @@
     # If in client mode then this only affects who RETCON connects to
     # if in transport mode, and host_ap == true then will also host an AP with this prefix
     prefix = "RT-DC33-"
-    psk = "hacktheplanet"
+    psk = "DChacktheplanet33"
 
     # only matters if in 'client' mode
-    client_ap_prefix = "RT-UI-DC33"
-    client_ap_psk = "thisisthepassword" 
+    client_ap_prefix = "UI-DC33-"
+    client_ap_psk = "hacktheplanet" 
     
     freq = 2462
     client_iface = 'wlan0'
     ap_iface = 'uap0'
   
+
+# meshchat config overrides. Only applies on first boot so user can customize after
+# These values need to match the exact keys in meshchat's database.db `config` table 
+[meshchat]
+  display_name = "Human [change me]"
+  lxmf_user_icon_name = "skull-crossbones-outline"
+  lxmf_preferred_propagation_node_destination_hash="afe402b7cd7ee5f5cca82da1963db84d"
+  lxmf_preferred_propagation_node_auto_sync_interval_seconds=1800
+  theme = "dark"
+  auto_announce_interval_seconds = 900
+
+
 # optional hardcoded interfaces section. Any interfaces you define here will be used as-is
 # Disabled for now. Keep the mesh separated
 # [interfaces]
@@ -45,15 +57,15 @@
       #port = /dev/ttyACM0 # Not needed since we auto-detect 
       frequency = 914875000
       bandwidth = 250000
-      txpower = 14
+      txpower = 16
       spreadingfactor = 6
       codingrate = 5
 
 
     #[[[meshtastic]]]
     #  mode = ap
-    #  data_speed = 6  # Radio speed setting desired for the network. see https://github.com/landandair/RNS_Over_Meshtastic
-    #  hop_limit = 5
+    #  data_speed = 8  # Radio speed setting desired for the network. see https://github.com/landandair/RNS_Over_Meshtastic
+    #  hop_limit = 3
 
   
     

--- a/retcon_profiles/dc33.config
+++ b/retcon_profiles/dc33.config
@@ -36,7 +36,7 @@
 [meshchat]
   display_name = "Human [change me]"
   lxmf_user_icon_name = "skull-crossbones-outline"
-  lxmf_preferred_propagation_node_destination_hash="afe402b7cd7ee5f5cca82da1963db84d"
+  lxmf_preferred_propagation_node_destination_hash="cd5c120acfd9437048f731fdd7564b0d"
   lxmf_preferred_propagation_node_auto_sync_interval_seconds=1800
   theme = "dark"
   auto_announce_interval_seconds = 900

--- a/start_retcon.sh
+++ b/start_retcon.sh
@@ -3,6 +3,9 @@
 sudo systemctl stop ssh || true
 sudo systemctl disable ssh || true
 
+echo "Starting retcon in 3"
+sleep 3
+
 # make sure our pwd is the same as the script
 cd "$(dirname "$0")"
 
@@ -11,7 +14,6 @@ source $HOME/.nvm/nvm.sh
 nvm use default
 
 
-echo "Starting retcon in 3"
-sleep 3
+
 python retcon.py
 

--- a/utils/admin.py
+++ b/utils/admin.py
@@ -53,6 +53,9 @@ class RetconAdmin:
         out, err = p.communicate()
         return out
             
+    def reset_reticulum_config(self):
+        subprocess.Popen(f"cd ~/.reticulum && rm -rf `ls ~/.reticulum | grep -v interfaces`", shell=True)
+    
     @property
     def ssh_enabled(self):
          p = subprocess.Popen("sudo systemctl status ssh", shell=True, stdout=subprocess.PIPE)
@@ -88,6 +91,17 @@ class RetconAdmin:
     @client_ap_psk.setter
     def client_ap_psk(self, psk):
         self.config["retcon"]['wifi']['client_ap_psk'] = psk
+        self.config["retcon"]['client_info_changed'] = True
+        self.write_config()
+        
+    @property
+    def client_ap_ssid(self):
+        print(self.config["retcon"]['wifi'])
+        return self.config["retcon"]['wifi'].get('client_ap_prefix',"")
+    
+    @client_ap_ssid.setter
+    def client_ap_ssid(self, ssid):
+        self.config["retcon"]['wifi']['client_ap_prefix'] = ssid
         self.config["retcon"]['client_info_changed'] = True
         self.write_config()
         

--- a/utils/client_web_ui/retcon_client_ui.py
+++ b/utils/client_web_ui/retcon_client_ui.py
@@ -32,8 +32,11 @@ def index():
 def wifi():
     try:
         post = json.loads(request.data)
+        client_ap_ssid = post["client_ap_ssid"]
         client_ap_psk = post["client_ap_psk"]
+        
         admin.client_ap_psk = client_ap_psk
+        admin.client_ap_ssid = client_ap_ssid
         
         return jsonify({ "message" : "Config Saved. Changes only take effect after a reboot.", "status": "ok"})
     except Exception as e:
@@ -75,6 +78,20 @@ def set_time():
         return jsonify({ "message" : "set", "status": "ok"})
     else:
         return jsonify({ "message" : f"{epoch} is not a valid unix epoch. Eopich must be int, and seconds. Must be between 1751917835 and  5000000000", "status": "error"})
+   
+   
+@app.route('/reset_reticulum_config', methods=['POST'])
+def reset_reticulum_config():
+    print("RESETTING", request.data)
+    post = json.loads(request.data)
+    do_it = post.get("do_reset", 0)
+    if do_it == 1:
+        admin.reset_reticulum_config()
+        time.sleep(1)
+        admin.reboot()
+        return jsonify({ "message" : "set", "status": "ok"})
+    else:
+        return jsonify({ "message" : "do_reset must be = 1"})
    
 # main driver function
 if __name__ == '__main__':

--- a/utils/client_web_ui/templates/index.html
+++ b/utils/client_web_ui/templates/index.html
@@ -28,7 +28,7 @@
     <div class="window" style="margin-left: auto; margin-right:auto; width: 800px">
       <div class="title-bar">
         <div class="title-bar-text">
-          RETCON!1!!One!1!  v0.0.5
+          RETCON!1!!One!1!  v0.0.6
         </div>
 
         <div class="title-bar-controls">
@@ -71,7 +71,7 @@
           
           <div class="field-row">
             <label class="large" for="wifi_ssid">Wifi SSID</label>
-            <input id="wifi_ssid" type="text" value="{{admin.name}}" disabled />
+            <input id="wifi_ssid" type="text" value="{{admin.name}}" />
           </div>
           <div class="field-row">
             <label class="large" for="client_ap_psk">Wifi Pass</label>
@@ -98,6 +98,10 @@
             <p> Commands </p>
             <button class="default" onclick="reboot()">Reboot Now</button>
             <button class="default" onclick="toggle_ssh()">Toggle SSH. (Currently Enabled={{ admin.ssh_enabled }})</button>
+          </div>
+          <div class="field-row-stacked" style="width: 760px">
+            <p> Danger Zone </p>
+            <button class="default" onclick="reset_reticulum_config()">Reset Reticulum Config (WARNING: THIS WILL ERASE EVERYTHING IN MESHCHAT)</button>
           </div>
         </div>
       </div>
@@ -144,6 +148,7 @@
       function save_wifi() {
         //just PSK for now
         data = {
+          client_ap_ssid: document.getElementById('wifi_ssid').value || "not set", 
           client_ap_psk: document.getElementById('client_ap_psk').value || "not set"
         }
 
@@ -220,6 +225,17 @@
       }
 
       sync_time();
+
+      function reset_reticulum_config () {
+        fetch("/reset_reticulum_config",  {method: "POST", body: JSON.stringify({do_reset:1}) })
+        .then(resp=> resp.json()
+            .then(msg=>{
+              if(msg.status === "ok") console.log(msg);
+              else console.error(msg)
+            }))
+
+            alert("Sent reset and reboot commands. Wait a few seconds then re-connect")
+      }
 
     </script>
   </body>

--- a/utils/client_web_ui/tls_proxy/proxy.js
+++ b/utils/client_web_ui/tls_proxy/proxy.js
@@ -17,7 +17,8 @@ if(bindIp) {
     ssl: {
         key: fs.readFileSync(homedir+'/.retcon/key.pem', 'utf8'),
         cert: fs.readFileSync(homedir+'/.retcon/cert.pem', 'utf8')
-    }
+    },
+    ws:true,
     }).listen(8443, bindIp);
 
     httpProxy.createServer({
@@ -28,7 +29,8 @@ if(bindIp) {
     ssl: {
         key: fs.readFileSync(homedir+'/.retcon/key.pem', 'utf8'),
         cert: fs.readFileSync(homedir+'/.retcon/cert.pem', 'utf8')
-    }
+    },
+    ws:true
     }).listen(443, bindIp);
 } else {
     console.log("Exiting, no bind ip set")

--- a/utils/meshchat_handler.py
+++ b/utils/meshchat_handler.py
@@ -2,6 +2,9 @@ import subprocess
 import os
 import netifaces as ni
 import time
+import sqlite3
+from glob import glob 
+
 
 class MeshchatHandle():
     
@@ -10,25 +13,80 @@ class MeshchatHandle():
     _tls_proxy_singletone = None
 
     @classmethod
-    def start_meshchat(cls, iface, ssid):
+    def start_meshchat(cls, iface, ssid, retcon_config):
         ip = ni.ifaddresses(iface)[ni.AF_INET][0]['addr']
         print(f"Starting Meshchat on {ip}")
         current_env = os.environ.copy()
         dir_path = os.path.dirname(os.path.realpath(__file__))
+        
+        
+        print("Modifying meshchat config")
+        cls.alter_meshchat_config(retcon_config)
+        
         cls._singleton = subprocess.Popen(
             f"python {dir_path}/../apps/reticulum-meshchat/meshchat.py --headless --host {ip}", 
             shell=True, env=current_env)
         
+        time.sleep(0.25)
+                
         print("starting retcon client homepage")
         # Also launch the retcon homepage!
         cls._homepage_singleton = subprocess.Popen(
             f"authbind --deep python {dir_path}/client_web_ui/retcon_client_ui.py {ssid}", 
             shell=True, env=current_env)
         
-        time.sleep(1)
+        time.sleep(0.25)
         
         print("starting retcon TLS proxy")
         # and the reverse proxy for tls
         cls._tls_proxy_singletone = subprocess.Popen(
             f"authbind --deep node proxy.js {ip}", 
             shell=True, env=current_env, cwd=f"{dir_path}/client_web_ui/tls_proxy")
+        
+       
+        
+    @classmethod
+    def alter_meshchat_config(cls, retcon_config):
+        
+        config = retcon_config.get("meshchat",{})
+        if len(config) == 0:
+            print("No meshchat config overrides. ejecting...")
+            return
+        
+        ident_path = os.path.expanduser("~/retcon/storage/identities/")
+        database_paths = glob( ident_path + "*/database.db")
+        if len(database_paths) == 0:
+            print(f"ERROR: Could not modify meshchat config. No database files at {ident_path}")
+            return
+        
+        for db_path in database_paths:
+            con = sqlite3.connect(db_path)
+            try:
+                cur = con.cursor()
+                
+                # have we already modified the config?
+                already_modified = cur.execute("SELECT value FROM config WHERE key='retcon_modified'").fetchone()
+                if already_modified is not None and already_modified == 1:
+                    print("Already modified, ejecting...")
+                    return
+                
+                # we haven't modified the config yet, let's do it
+                for key, val in config.items():
+                    print(f"Setting {key}={val}")
+                    cur.execute("INSERT into config (key, value, created_at, updated_at) VALUES (?, ?, datetime(), datetime()) "
+                        "ON CONFLICT(key) DO UPDATE SET value=?", (key, val, val))
+                
+                # finally upsert the retcon_modified key so we know we've already done this
+                if already_modified is None:
+                    cur.execute("INSERT into config (key, value, created_at, updated_at) VALUES ('retcon_modified', 1, datetime(), datetime())")
+                else:
+                    cur.execute("UPDATE config SET value=1 WHERE key='retcon_modified'")
+                    
+                con.commit()
+            finally:
+                con.close()
+        
+        
+        
+                              
+        

--- a/utils/meshchat_handler.py
+++ b/utils/meshchat_handler.py
@@ -3,9 +3,14 @@ import os
 import netifaces as ni
 import time
 import sqlite3
+from jinja2 import Template
 from glob import glob 
 
-
+restart_template = """
+until {{command}}; do
+    echo "{{command}} crashed. Restarting"
+done
+"""
 class MeshchatHandle():
     
     _singleton = None
@@ -24,7 +29,7 @@ class MeshchatHandle():
         cls.alter_meshchat_config(retcon_config)
         
         cls._singleton = subprocess.Popen(
-            f"python {dir_path}/../apps/reticulum-meshchat/meshchat.py --headless --host {ip}", 
+            Template(restart_template).render(command=f"python {dir_path}/../apps/reticulum-meshchat/meshchat.py --headless --host {ip}"), 
             shell=True, env=current_env)
         
         time.sleep(0.25)
@@ -32,7 +37,7 @@ class MeshchatHandle():
         print("starting retcon client homepage")
         # Also launch the retcon homepage!
         cls._homepage_singleton = subprocess.Popen(
-            f"authbind --deep python {dir_path}/client_web_ui/retcon_client_ui.py {ssid}", 
+            Template(restart_template).render(command=f"authbind --deep python {dir_path}/client_web_ui/retcon_client_ui.py {ssid}"), 
             shell=True, env=current_env)
         
         time.sleep(0.25)
@@ -40,7 +45,7 @@ class MeshchatHandle():
         print("starting retcon TLS proxy")
         # and the reverse proxy for tls
         cls._tls_proxy_singletone = subprocess.Popen(
-            f"authbind --deep node proxy.js {ip}", 
+            Template(restart_template).render(command=f"authbind --deep node proxy.js {ip}"), 
             shell=True, env=current_env, cwd=f"{dir_path}/client_web_ui/tls_proxy")
         
        

--- a/utils/meshchat_handler.py
+++ b/utils/meshchat_handler.py
@@ -65,8 +65,8 @@ class MeshchatHandle():
                 cur = con.cursor()
                 
                 # have we already modified the config?
-                already_modified = cur.execute("SELECT value FROM config WHERE key='retcon_modified'").fetchone()
-                if already_modified is not None and already_modified == 1:
+                already_modified = cur.execute("SELECT value FROM config WHERE key='retcon_modified';").fetchone()
+                if already_modified is not None and (already_modified[0] == 1 or already_modified[0] == '1'):
                     print("Already modified, ejecting...")
                     return
                 


### PR DESCRIPTION
- Ability to define meshchat config from RETCON config file. (MVP. Requires restart on first boot for now)
- Moved wifi mesh tp use TCP instead of Auto for much better reliability with changing network topology. 
- Added more info to README and install scripts based on user feedback
- Added restart logic to daemon processes so an errant crash won't cause the system to stop responding. 